### PR TITLE
Add caching mechanism to WeatherProvider for API calls

### DIFF
--- a/lib/providers/weather_provider.dart
+++ b/lib/providers/weather_provider.dart
@@ -3,6 +3,9 @@ import 'package:pasada_passenger_app/services/weather_service.dart';
 
 class WeatherProvider extends ChangeNotifier {
   final WeatherService _service = WeatherService();
+  // Cache duration to limit API calls
+  static const Duration _cacheDuration = Duration(minutes: 7);
+  DateTime? _lastFetchTime;
 
   Weather? _weather;
   bool _isLoading = false;
@@ -14,6 +17,13 @@ class WeatherProvider extends ChangeNotifier {
   bool get isRaining => _weather?.isRaining ?? false;
 
   Future<void> fetchWeather(double lat, double lon) async {
+    final now = DateTime.now();
+    // Skip fetching if within cache duration
+    if (_lastFetchTime != null &&
+        now.difference(_lastFetchTime!) < _cacheDuration) {
+      return;
+    }
+    _lastFetchTime = now;
     _isLoading = true;
     _error = null;
     notifyListeners();


### PR DESCRIPTION
- Introduced a cache duration of 7 minutes to limit unnecessary API calls.
- Implemented logic to skip fetching weather data if the last fetch was within the cache duration.
- Updated fetchWeather method to utilize the new caching mechanism, improving performance and reducing load on the weather service.